### PR TITLE
correctly match floating point rank scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 3.14.2
+
+* Fix rankscore parsing in `cnv2bed.pl`
+
 ### 3.14.1
 
 * Adds basic flake8-based linting 

--- a/bin/cnv2bed.pl
+++ b/bin/cnv2bed.pl
@@ -36,7 +36,7 @@ if( defined($opt{cnv}) ){
             next if( $cols[ $labels{ $opt{pb} } ] =~/^\.\// );
             if( $row =~/SVTYPE=(\w+);/ ) { $svtype = $1; next if( $svtype eq 'BND' ); }
             if( $row =~/END=(\d+);/ ){ $end = $1; }
-            if( $row =~/RankScore=$opt{pb}:([\d-]+);/ ){ $score = $1; next if( $score <= $SCORE ); }
+            if( $row =~/RankScore=$opt{pb}:([\d-.]+);/ ){ $score = $1; next if( $score <= $SCORE ); }
             if( $row =~/RankResult=([\d-]+)\|/ ){ $rank = $1; }
             if( $svtype =~/DEL/ ){ $color = '204,0,0'; }elsif( $svtype =~/DUP/ ){ $color = '0,0,153'; }
             print "chr$cols[0]\t".( $cols[1] - 1 )."\t$end\t\"$svtype,score=$score\"\t0\t\.\t0\t0\t$color\n";


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Fixes #277 

`cnv2bed.pl` uses regex match that extracts rank scores, expecting integers. however, since the merge of #247 the rank scores are encoded as floats, which breaks the rank score threshold filter

this patch adjusts the regex to also catch floats.

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [ ] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Patch
- [x] Stub run completes without errors or new warnings
- [x] At least one other person has reviewed and approved my code (not required for trivial changes)
- [x] rank score filter works again, producing correctly filtered bed files

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [x] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
