### PR TITLE
Add rename_bam workaround for copy_bam process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### TBA
+* Add temp copybam workaround to emit the copied files instead of original input bams
+
 ### 3.15.5
 * Update GNOMAD genomes and exomes to v4.1 in `annotate_vep` and `indel_vep`
 * Update popmax attribute to grpmax (same attribute renamed in v4: https://gnomad.broadinstitute.org/news/2023-11-genetic-ancestry/) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
-### TBA
-* Add temp copybam workaround to emit the copied files instead of original input bams
+### 3.15.6
+* Add workaround so copybam actually emits copied BAMs
 
 ### 3.15.5
 * Update GNOMAD genomes and exomes to v4.1 in `annotate_vep` and `indel_vep`


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

A process is added that symlinks input bams under a dummy filename and emits the symlink to copy_bam. This allows copy_bam to do its work and emit the copied bam files under the original filename.

This _partially_ resolves #306 , but will still not fix rerunning samples with renamed bams. Please see original issue for more info on how to fix this the proper way.

## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)
- [x] Seracare (onco) sample finishes 

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [x] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
