### PR TITLE
theano flag correctly set for postprocess gatk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.15.10
+* theano base_dir flag was not exported correctly for postprocess GATK. Should stop random crashes from happening
+
 ### 3.15.9
 Update sentieon from 202308.01 to 202308.03
 

--- a/main.nf
+++ b/main.nf
@@ -2982,7 +2982,7 @@ process postprocessgatk {
 		caseshards = caseshards.join( ' --calls-shard-path ')
 		version_str = postprocessgatk_version(task)
 		"""
-		THEANO_FLAGS="base_compiledir=/fs1/resources/theano"
+		export THEANO_FLAGS="base_compiledir=."
 
 		for model in ${tar}; do
 			tar -xvf \$model
@@ -3021,7 +3021,7 @@ process postprocessgatk {
 		caseshards = caseshards.join( ' --calls-shard-path ')
 		version_str = postprocessgatk_version(task)
 		"""
-		THEANO_FLAGS="base_compiledir=/fs1/resources/theano"
+		export THEANO_FLAGS="base_compiledir=."
 		set +u
 		source activate gatk
 		export MKL_NUM_THREADS=${task.cpus}


### PR DESCRIPTION
# Description and reviewer info
Correct export of environment variable THEANO_FLAGS for postprocess gatk. No need for review

## Type of change

- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)


## Testing performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [x] Viktor
