### PR TITLE
Remove params.antype from named workflows and processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Changed
 * Pass the CFTR annotation flag through `NEXTFLOW_WGS` into `SNV_ANNOTATE` instead of reading `params.cftr` inside named workflows
+* Pass SNV split/normalize reference FASTA and index through workflow inputs instead of reading the reference FASTA from global params
+* Pass analysis type through workflow/process inputs instead of reading `params.antype` from global params
 
 ### 3.28.0
 

--- a/main.nf
+++ b/main.nf
@@ -342,7 +342,7 @@ workflow NEXTFLOW_WGS {
 			val_vcfanno_lua,
 			val_run_freebayes
 		)
-		SPLIT_NORMALIZE_SNVS(CALL_SNVS.out.group_vcf_tbi, val_intersect_bed)
+		SPLIT_NORMALIZE_SNVS(CALL_SNVS.out.group_vcf_tbi, val_intersect_bed, val_genome_fasta)
 		ch_snv_vcf_tbi_full = SPLIT_NORMALIZE_SNVS.out.vcf_tbi_full
 		ch_snv_vcf_tbi_intersected = SPLIT_NORMALIZE_SNVS.out.vcf_tbi_intersected
 		ch_sample_gvcf_tbi = CALL_SNVS.out.sample_gvcf_tbi

--- a/main.nf
+++ b/main.nf
@@ -93,6 +93,7 @@ workflow {
 		"${params.outdir}/${params.subdir}",
 		params.noupload,
         params.cftr
+        params.antype,
         params.antype == "wgs"
 	)
 
@@ -194,6 +195,7 @@ workflow NEXTFLOW_WGS {
 	val_results_output_dir                     // string:  Full result base directory under which pipeline results are published.
 	val_skip_cdm_cron                          // bool:    Whether to skip creating CDM QC cron files.        
 	val_run_cftr                               // bool:    Whether to rescore CFTR 5T/TG homopolymer variants.
+    val_analysis_type                          // string:  Analysis type, either "panel" or "wgs" 
     val_run_contamination_qc                   // bool:    Whether to run contamination QC
 
 	main:
@@ -299,7 +301,7 @@ workflow NEXTFLOW_WGS {
 			if (val_run_melt && !qc.ins_size) {
 				error "Missing required MELT QC value 'ins_size' for ${id}"
 			}
-			if ((val_run_melt || params.antype == "panel") && !qc.mean_depth) {
+			if ((val_run_melt || val_analysis_type == "panel") && !qc.mean_depth) {
 				error "Missing required QC value 'mean_coverage' for ${id}"
 			}
 
@@ -469,8 +471,8 @@ workflow NEXTFLOW_WGS {
 		ch_peddy2cdm = peddy.out.peddy_files.join(ch_peddy2cdm_input)
 			
 		peddy2cdm(ch_peddy2cdm)
-		
-		if (params.antype == "wgs") {
+
+		if (val_analysis_type == "wgs") {
 			// fastgnomad
 			fastgnomad(
                 ch_snv_vcf_tbi_full
@@ -628,7 +630,7 @@ workflow NEXTFLOW_WGS {
 
 
 		ch_manta_out = channel.empty()
-		if (params.antype == "wgs") {
+		if (val_analysis_type == "wgs") {
 			manta(ch_bam_bai)
 			ch_manta_out = ch_manta_out.mix(manta.out.vcf)
 			tiddit(ch_bam_bai)
@@ -667,7 +669,7 @@ workflow NEXTFLOW_WGS {
 		
 		ch_cnvkit_cns_cnr = channel.empty()
 
-        if (params.antype == "panel") {
+        if (val_analysis_type == "panel" && params.sv) {
 			ch_panel_merge = channel.empty()
 			manta_panel(ch_bam_bai)
 			ch_manta_out = ch_manta_out.mix(manta_panel.out.vcf)
@@ -803,7 +805,7 @@ workflow NEXTFLOW_WGS {
 		ch_versions = ch_versions.mix(bgzip_scored_genmod.out.versions.first())
 
 		// TODO: streamline if-conditions:
-		if(params.antype == "wgs" && val_is_trio && val_analysis_mode == "family") {
+		if(val_analysis_type == "wgs" && val_is_trio && val_analysis_mode == "family") {
 			ch_plot_pod_in = fastgnomad.out.vcf
 				.join(bgzip_scored_genmod.out.sv_rescore_vcf, by: [0])
 				.join(ch_ped_base, by: [0])

--- a/main.nf
+++ b/main.nf
@@ -346,7 +346,7 @@ workflow NEXTFLOW_WGS {
 			val_vcfanno_lua,
 			val_run_freebayes
 		)
-		SPLIT_NORMALIZE_SNVS(CALL_SNVS.out.group_vcf_tbi, val_intersect_bed, val_genome_fasta)
+		SPLIT_NORMALIZE_SNVS(CALL_SNVS.out.group_vcf_tbi, val_intersect_bed, val_genome_fasta, val_genome_fai)
 		ch_snv_vcf_tbi_full = SPLIT_NORMALIZE_SNVS.out.vcf_tbi_full
 		ch_snv_vcf_tbi_intersected = SPLIT_NORMALIZE_SNVS.out.vcf_tbi_intersected
 		ch_sample_gvcf_tbi = CALL_SNVS.out.sample_gvcf_tbi

--- a/main.nf
+++ b/main.nf
@@ -2030,9 +2030,6 @@ process fastgnomad {
 	output:
 		tuple val(group), path("${group}.SNPs.vcf.gz"), emit: vcf
 
-	when:
-		params.antype == "wgs"
-
 	script:
 		"""
 		fastgnomad -g $params.FASTGNOMAD_REF -i ${vcf} | bgzip -c > ${group}.SNPs.vcf.gz

--- a/main.nf
+++ b/main.nf
@@ -777,7 +777,11 @@ workflow NEXTFLOW_WGS {
 			.map { group, sv_vcf, _proband_id, meta ->
 				tuple(group, sv_vcf, meta)
 			}
-		svvcf_to_bed(ch_svvcf_to_bed_in)
+        
+        if(val_analysis_type != "panel") {
+            svvcf_to_bed(ch_svvcf_to_bed_in)
+        }
+		
 
         ch_cnvkit_plot_snvs = ch_snv_vcf_tbi_intersected
             .map { group, vcf, _tbi -> [ group, vcf ] }
@@ -3825,10 +3829,6 @@ process svvcf_to_bed {
 
 	output:
 		path("${group}.sv.bed")
-
-	when:
-		params.antype != "panel"
-
 
 	script:
 		"""

--- a/main.nf
+++ b/main.nf
@@ -2740,9 +2740,6 @@ process manta_panel {
 		tuple val(group), val(id), path("${id}.manta.vcf.gz"), emit: vcf
 		path "*versions.yml", emit: versions
 
-	when:
-		params.sv && params.antype == "panel"
-
 	script:
 		"""
 		configManta.py --bam $bam --reference ${params.genome_file} --runDir . --exome --callRegions $params.bedgz --generateEvidenceBam

--- a/main.nf
+++ b/main.nf
@@ -93,6 +93,7 @@ workflow {
 		"${params.outdir}/${params.subdir}",
 		params.noupload,
         params.cftr
+        params.antype == "wgs"
 	)
 
 	ch_versions = ch_versions.mix(NEXTFLOW_WGS.out.versions).collect()
@@ -193,6 +194,7 @@ workflow NEXTFLOW_WGS {
 	val_results_output_dir                     // string:  Full result base directory under which pipeline results are published.
 	val_skip_cdm_cron                          // bool:    Whether to skip creating CDM QC cron files.        
 	val_run_cftr                               // bool:    Whether to rescore CFTR 5T/TG homopolymer variants.
+    val_run_contamination_qc                   // bool:    Whether to run contamination QC
 
 	main:
 	// Output channels:
@@ -353,7 +355,7 @@ workflow NEXTFLOW_WGS {
     ch_rename_mito_contigs_in = channel.empty() 
 
 	// CONTAMINATION //
-	if (params.antype == "wgs") {
+	if (val_run_contamination_qc) {
 		verifybamid2(ch_bam_bai)
 		ch_qc_json = ch_qc_json.mix(verifybamid2.out.contamination_json)
 		ch_versions = ch_versions.mix(verifybamid2.out.versions.first())

--- a/main.nf
+++ b/main.nf
@@ -770,7 +770,7 @@ workflow NEXTFLOW_WGS {
 		add_geneticmodels_to_svvcf(ch_add_geneticmodels_to_svvcf_input)
 		score_sv(
             add_geneticmodels_to_svvcf.out.annotated_sv_vcf,
-            analysis_mode == "family" && analysis_type == "wgs"
+            val_analysis_mode == "family" && val_analysis_type == "wgs"
         )
 		bgzip_scored_genmod(score_sv.out.scored_vcf.mix(ch_panel_svs_absent))
 		ch_output_info = ch_output_info.mix(bgzip_scored_genmod.out.sv_INFO)

--- a/main.nf
+++ b/main.nf
@@ -491,7 +491,7 @@ workflow NEXTFLOW_WGS {
 				}
 
 			// upd
-            // TODO: upd process creates dummy files is not in trio mode, used later in
+            // TODO: upd process creates dummy files if not run in trio mode, used later in
             //       a long gens input channel join. move upd into block below and find
             //       better solution for skipping upd inputs to gens
 			upd(fastgnomad.out.vcf, ch_upd_meta, val_analysis_mode, val_is_trio)

--- a/main.nf
+++ b/main.nf
@@ -876,7 +876,10 @@ workflow NEXTFLOW_WGS {
 	// OUTPUT INFO
 	output_files(ch_output_info.groupTuple())
 	// SCOUT YAML
-	create_yaml(ch_proband_meta.join(ch_ped_base).join(output_files.out.yaml_INFO))
+	create_yaml(
+        ch_proband_meta.join(ch_ped_base).join(output_files.out.yaml_INFO),
+        val_analysis_type
+    )
 	emit:
 		versions = ch_versions
 }
@@ -3879,7 +3882,8 @@ process create_yaml {
 	memory '1 GB'
 
 	input:
-		tuple val(group), val(id), val(meta), val(type), path(ped), path(INFO)
+	tuple val(group), val(id), val(meta), val(type), path(ped), path(INFO)
+    val analysis_type
 
 	output:
 		tuple val(group), path("${group}.yaml*"), emit: scout_yaml
@@ -3895,7 +3899,7 @@ process create_yaml {
 			--ped "$ped" \\
 			--files "$INFO" \\
 			--assay "$assay" \\
-			--antype "$params.antype" \\
+	        --antype "${analysis_type}" \\
 			--status "${meta.priority}" \\
 			--extra_panels "$params.extra_panels"
 		"""

--- a/main.nf
+++ b/main.nf
@@ -64,6 +64,9 @@ workflow {
 	ch_samplesheet = VALIDATE_SAMPLES_CSV.out.validated_csv
 		.splitCsv(header: true)
 
+    val_run_contamination_qc = params.antype == "wgs"
+    val_use_family_wgs_genmod_scoring = val_analysis_mode == "family" && params.antype == "wgs"
+
 	NEXTFLOW_WGS(
 		ch_samplesheet,
 		params.bqsr_known_polymorphic_sites_vcf,
@@ -94,7 +97,8 @@ workflow {
 		params.noupload,
         params.cftr,
         params.antype,
-        params.antype == "wgs"
+        val_run_contamination_qc,
+        val_use_family_wgs_genmod_scoring
 	)
 
 	ch_versions = ch_versions.mix(NEXTFLOW_WGS.out.versions).collect()
@@ -197,6 +201,7 @@ workflow NEXTFLOW_WGS {
 	val_run_cftr                               // bool:    Whether to rescore CFTR 5T/TG homopolymer variants.
     val_analysis_type                          // string:  Analysis type, either "panel" or "wgs" 
     val_run_contamination_qc                   // bool:    Whether to run contamination QC
+    val_use_family_wgs_genmod_scoring          // bool:    Whether SNV and SV scoring should use family WGS genmod/rank-model behavior.
 
 	main:
 	// Output channels:
@@ -427,7 +432,7 @@ workflow NEXTFLOW_WGS {
         
 	// SNV ANNOTATION
 	if (val_annotate) {
-		
+
 		// bam channel for SNV annotate, special case //
 		ch_bam_bai_snv_annotate_in = ch_bam_bai
 			.join(ch_proband_meta, by: [0,1])
@@ -436,8 +441,7 @@ workflow NEXTFLOW_WGS {
 		    }
 
         ch_snv_annotate_in = ch_snv_annotate_in.mix(ch_vcf_start)
-        
-		val_use_family_wgs_genmod_scoring = val_analysis_mode == "family" && val_analysis_type == "wgs"
+
 		SNV_ANNOTATE(
             ch_bam_bai_snv_annotate_in,
             ch_snv_annotate_in,
@@ -469,7 +473,7 @@ workflow NEXTFLOW_WGS {
 		// add peddy output to each trio case, make sure it is matched on group
 		// combine does not do this and join will only take first entry
 		ch_peddy2cdm = peddy.out.peddy_files.join(ch_peddy2cdm_input)
-			
+
 		peddy2cdm(ch_peddy2cdm)
 
 		if (val_analysis_type == "wgs") {
@@ -770,7 +774,7 @@ workflow NEXTFLOW_WGS {
 		add_geneticmodels_to_svvcf(ch_add_geneticmodels_to_svvcf_input)
 		score_sv(
             add_geneticmodels_to_svvcf.out.annotated_sv_vcf,
-            val_analysis_mode == "family" && val_analysis_type == "wgs"
+            val_use_family_wgs_genmod_scoring
         )
 		bgzip_scored_genmod(score_sv.out.scored_vcf.mix(ch_panel_svs_absent))
 		ch_output_info = ch_output_info.mix(bgzip_scored_genmod.out.sv_INFO)

--- a/main.nf
+++ b/main.nf
@@ -1566,10 +1566,7 @@ process sentieon_mitochondrial_qc {
 	output:
     	tuple val(group), val(id), path("${id}_mito_coverage.tsv"), emit: qc_tsv
 		path "*versions.yml", emit: versions
-
-	when:
-	    params.antype == "wgs"
-
+	
 	script:
 		"""
 		sentieon driver \\

--- a/main.nf
+++ b/main.nf
@@ -3030,8 +3030,9 @@ process tiddit {
 		path "*versions.yml", emit: versions
 
 
+    
 	when:
-		params.sv && params.antype == "wgs"
+		params.sv
 
 	script:
 		"""

--- a/main.nf
+++ b/main.nf
@@ -92,7 +92,7 @@ workflow {
 		params.cdm_assay,
 		"${params.outdir}/${params.subdir}",
 		params.noupload,
-        params.cftr
+        params.cftr,
         params.antype,
         params.antype == "wgs"
 	)

--- a/main.nf
+++ b/main.nf
@@ -437,7 +437,7 @@ workflow NEXTFLOW_WGS {
 
         ch_snv_annotate_in = ch_snv_annotate_in.mix(ch_vcf_start)
         
-		val_use_family_wgs_genmod_scoring = val_analysis_mode == "family" && params.antype == "wgs"
+		val_use_family_wgs_genmod_scoring = val_analysis_mode == "family" && val_analysis_type == "wgs"
 		SNV_ANNOTATE(
             ch_bam_bai_snv_annotate_in,
             ch_snv_annotate_in,

--- a/main.nf
+++ b/main.nf
@@ -768,7 +768,10 @@ workflow NEXTFLOW_WGS {
 				tuple(group, type, ped, penalty_vcf)
 			}
 		add_geneticmodels_to_svvcf(ch_add_geneticmodels_to_svvcf_input)
-		score_sv(add_geneticmodels_to_svvcf.out.annotated_sv_vcf, val_analysis_mode)
+		score_sv(
+            add_geneticmodels_to_svvcf.out.annotated_sv_vcf,
+            analysis_mode == "family" && analysis_type == "wgs"
+        )
 		bgzip_scored_genmod(score_sv.out.scored_vcf.mix(ch_panel_svs_absent))
 		ch_output_info = ch_output_info.mix(bgzip_scored_genmod.out.sv_INFO)
 
@@ -3661,15 +3664,18 @@ process score_sv {
 	container  "${params.container_genmod}"
 
 	input:
-		tuple val(group), val(type), path(in_vcf)
-		val analysis_mode
+	    tuple val(group), val(type), path(in_vcf)
+        val use_family_wgs_scoring
+
 
 	output:
 		tuple val(group), val(type), path("*.sv.scored.vcf"), emit: scored_vcf
 		path "*versions.yml", emit: versions
 
 	script:
-		def model = (analysis_mode == "family" && params.antype == "wgs") ? params.svrank_model : params.svrank_model_s
+        // TODO: Decide on model outside of the process and pass it as an input to model
+        // instead of the conditional below:
+		def model = use_family_wgs_scoring ? params.svrank_model : params.svrank_model_s
 		def group_score = ( type == "ma" || type == "fa" ) ? "${group}_${type}" : group
 		"""
 		genmod score --family_id ${group_score} --score_config ${model} --rank_results --outfile "${group_score}.sv.scored.vcf" ${in_vcf}

--- a/workflows/split_normalize_snvs.nf
+++ b/workflows/split_normalize_snvs.nf
@@ -4,12 +4,13 @@ workflow SPLIT_NORMALIZE_SNVS {
     ch_family_snv_vcf_idx // channel: [val(group_id), path(family_vcf), path(family_tbi)]
     val_intersect_bed     // path value: BED file used for intersecting normalized SNVs.
     val_genome_fasta      // path value: Reference FASTA used by bcftools norm.
+    val_genome_fai        // path value: Reference FASTA index used by bcftools norm.
 
     main:
     ch_versions = channel.empty()
     
     vcflib_vcfbreakmulti(ch_family_snv_vcf_idx)
-    bcftools_norm_sort(vcflib_vcfbreakmulti.out.vcf_tbi, val_genome_fasta)
+    bcftools_norm_sort(vcflib_vcfbreakmulti.out.vcf_tbi, val_genome_fasta, val_genome_fai)
     vcflib_vcfuniq(bcftools_norm_sort.out.vcf_tbi)
     wgs_dpaf_filter(vcflib_vcfuniq.out.vcf_tbi)
     bedtools_intersect(wgs_dpaf_filter.out.vcf_tbi, val_intersect_bed)
@@ -77,6 +78,7 @@ process bcftools_norm_sort {
     input:
         tuple val(group), path(vcf), path(idx)
         path genome_fasta
+        path genome_fai
     
     output:
 	    tuple val(group), path("${group}.norm.vcf.gz"), path("${group}.norm.vcf.gz.tbi"), emit: vcf_tbi

--- a/workflows/split_normalize_snvs.nf
+++ b/workflows/split_normalize_snvs.nf
@@ -2,16 +2,17 @@ workflow SPLIT_NORMALIZE_SNVS {
 
     take:
     ch_family_snv_vcf_idx // channel: [val(group_id), path(family_vcf), path(family_tbi)]
-    bed_intersect         // value:   [path(bed_intersect)]
+    val_intersect_bed     // path value: BED file used for intersecting normalized SNVs.
+    val_genome_fasta      // path value: Reference FASTA used by bcftools norm.
 
     main:
     ch_versions = channel.empty()
     
     vcflib_vcfbreakmulti(ch_family_snv_vcf_idx)
-    bcftools_norm_sort(vcflib_vcfbreakmulti.out.vcf_tbi)
+    bcftools_norm_sort(vcflib_vcfbreakmulti.out.vcf_tbi, val_genome_fasta)
     vcflib_vcfuniq(bcftools_norm_sort.out.vcf_tbi)
     wgs_dpaf_filter(vcflib_vcfuniq.out.vcf_tbi)
-    bedtools_intersect(wgs_dpaf_filter.out.vcf_tbi, bed_intersect)
+    bedtools_intersect(wgs_dpaf_filter.out.vcf_tbi, val_intersect_bed)
     bgzip_tabix(bedtools_intersect.out.intersected_vcf)
     
     ch_versions = ch_versions.mix(vcflib_vcfbreakmulti.out.versions.first())
@@ -74,7 +75,9 @@ process bcftools_norm_sort {
     publishDir "${params.outdir}/${params.subdir}/vcf", mode: 'copy', overwrite: true, pattern: '*.vcf.gz'
     
     input:
-		tuple val(group), path(vcf), path(idx)
+        tuple val(group), path(vcf), path(idx)
+        path genome_fasta
+    
     output:
 	    tuple val(group), path("${group}.norm.vcf.gz"), path("${group}.norm.vcf.gz.tbi"), emit: vcf_tbi
         path "*versions.yml", emit: versions
@@ -83,7 +86,7 @@ process bcftools_norm_sort {
     //        and adding --rm-dup flag to norm
     script:
     """
-    bcftools norm -m-both -c w -f ${params.genome_file} ${vcf} |\
+    bcftools norm -m-both -c w -f ${genome_fasta} ${vcf} |\
         bcftools sort -O z --write-index=tbi -o ${group}.norm.vcf.gz
 
     ${bcftools_norm_version(task)}


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

This update removes instances of `params.antype`  being read from named workflows or processes.

Also, a stray `params.genome_file` is removed from a process in `SPLIT_NORMALIZE_SNVS`. 


## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [ ] Patch
- [x] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Documentation
- [ ] At least one other person has reviewed my changes (not required for trivial changes)

## Patch
- [ ] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

## Major / Minor change

- [x] Stub run completes without errors or new warnings
- [x] GIAB single (wgs) finishes and differences to current master branch have been investigated (using [PipeEval](https://github.com/Clinical-Genomics-Lund/PipeEval))
- [x] GIAB trio (wgs) finishes and differences to current master branch have been investigated
- [x] Seracare (onco) sample finishes and differences to current master branch have been investigated
- [x] Output from processes with altered code have been inspected (i.e. in the work folder: .command.sh, .command.log, .command.err and result files)
- [ ] If relevant for your changes - All three samples can be loaded into Scout
- [x] At least one other person has reviewed and approved my code
- [ ] I have made corresponding changes to the documentation (software versions, etc.)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [x] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
