### PR TITLE
Fix access of removed var analysis_mode in score_sv tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Pass SNV split/normalize reference FASTA and index through workflow inputs instead of reading the reference FASTA from global params
 * Pass analysis type through workflow/process inputs instead of reading `params.antype` from global params
 
+#### Removed
+* Analysis mode (single/trio) from score_sv tag
+
 ### 3.28.0
 
 #### Added 

--- a/main.nf
+++ b/main.nf
@@ -3661,7 +3661,7 @@ def add_geneticmodels_to_svvcf_version(task) {
 }
 
 process score_sv {
-	tag "$group $analysis_mode"
+	tag "$group"
 	cpus 2
 	memory '10 GB'
 	time '2h'


### PR DESCRIPTION
<!--
Thanks for contributing to the CMD nextflow_wgs pipeline!

Please use the checklists below to document changes and performed tests.

Remember that this template doubles as our test/review documentation. 
-->
# Description and reviewer info

Forgot to remove a variable that is no longer available to score_sv from this process' tag definition.


## Type of change
<!--
    Major change counts as a change that breaks backward compatibility
    Minor change is a substantial change that requires testing before deployment
    Patch is a minor change like a bug fix, code comment/style fix, etc.
-->
- [ ] Documentation
- [x] Patch
- [ ] Minor change
- [ ] Major change 

# Checklist

- [x] Self-review of my code
- [x] Update the CHANGELOG
- [ ] Tag the latest commit (vX.Y.Z format)

<!--
    Select a checklist below based on selection under # Type of change
    and delete the sections that do not apply to this PR:
-->

## Patch
- [x] Stub run completes without errors or new warnings
- [ ] At least one other person has reviewed and approved my code (not required for trivial changes)

# Test/review documentation

## Review performed by

- [ ] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor

(Add if missing)

## Testing performed by

- [x] Alexander
- [ ] Jakob
- [ ] Paul
- [ ] Ryan
- [ ] Viktor
